### PR TITLE
Also adjust console font size

### DIFF
--- a/AdjustFontSize/ZTSAdjustFontSize.m
+++ b/AdjustFontSize/ZTSAdjustFontSize.m
@@ -93,6 +93,8 @@ static ZTSAdjustFontSize *sharedPlugin;
         [currentTheme setFont:modifier(font)
                  forNodeTypes:indexSet];
     }];
+    
+    [self _updateConsoleFontsWithModifier:modifier];
 }
 
 #pragma mark - Private
@@ -150,6 +152,22 @@ static ZTSAdjustFontSize *sharedPlugin;
         NSFont *font = [weakTheme fontForNodeType:[nodeId integerValue]];
         block(font, [nodeId integerValue], stop);
     }];
+}
+
+- (void)_updateConsoleFontsWithModifier:(ZTSFontModifier)modifier {
+    __weak DVTFontAndColorTheme *currentTheme = [self _currentTheme];
+    NSArray *consoleTextKeys = @[@"_consoleDebuggerPromptTextFont",
+                                 @"_consoleDebuggerInputTextFont",
+                                 @"_consoleDebuggerOutputTextFont",
+                                 @"_consoleExecutableInputTextFont",
+                                 @"_consoleExecutableOutputTextFont"];
+    
+    for (NSString *key in consoleTextKeys) {
+        NSFont *font = [currentTheme valueForKey:key];
+        NSFont *modifiedFont = modifier(font);
+        
+        [currentTheme setValue:modifiedFont forKey:key];
+    };
 }
 
 @end


### PR DESCRIPTION
This works, but there seems to be a small bug in Xcode. When adjusting sizes, if you switch directions (from ⌘- to ⌘+ or vice versa), the first size change is not correct. Checking the console font size in preference panel shows that it's correct, but Xcode renders it incorrectly. Any ideas?

<table>
  <tr>
    <th></th>
    <th colspan="2">Size (visually)</th>
    <th colspan="2">Size (acutal)</th>
  </tr>
  <tr>
    <td>Action<br></td>
    <td>Before</td>
    <td>After</td>
    <td>Before</td>
    <td>After</td>
  </tr>
  <tr>
    <td>⌘+</td>
    <td>10</td>
    <td>10</td>
    <td>10</td>
    <td>11</td>
  </tr>
  <tr>
    <td>⌘+</td>
    <td>10</td>
    <td>11</td>
    <td>11</td>
    <td>12</td>
  </tr>
  <tr>
    <td>⌘+</td>
    <td>11</td>
    <td>12</td>
    <td>12</td>
    <td>13</td>
  </tr>
  <tr>
    <td>⌘-</td>
    <td>12</td>
    <td>13</td>
    <td>13</td>
    <td>12</td>
  </tr>
  <tr>
    <td>⌘-</td>
    <td>13</td>
    <td>12</td>
    <td>12</td>
    <td>11</td>
  </tr>
</table>