### PR TITLE
Reintroduce independent editor/console adjustment via user preference

### DIFF
--- a/AdjustFontSize/ZTSAdjustFontSize.m
+++ b/AdjustFontSize/ZTSAdjustFontSize.m
@@ -130,7 +130,7 @@ static NSString *const ZTSAdjustFontSizeIndependentZoomKey = @"ZTSAdjustFontSize
     NSMenuItem *menuItem = [[NSApp mainMenu] itemWithTitle:@"View"];
     if (menuItem) {
         [[menuItem submenu] addItem:[NSMenuItem separatorItem]];
-        NSMenuItem *fontSize = [[menuItem submenu] addItemWithTitle:@"Font size"
+        NSMenuItem *fontSize = [[menuItem submenu] addItemWithTitle:@"Font Size"
                                                              action:nil
                                                       keyEquivalent:@""];
         NSMenu *submenu = [[NSMenu alloc] init];
@@ -146,7 +146,7 @@ static NSString *const ZTSAdjustFontSizeIndependentZoomKey = @"ZTSAdjustFontSize
                                            keyEquivalent:@"-"];
         decrease.target = self;
         
-        NSMenuItem *independentZoom = [submenu addItemWithTitle:@"Adjust editor and console independently"
+        NSMenuItem *independentZoom = [submenu addItemWithTitle:@"Adjust Editor and Console Independently"
                                                          action:@selector(_saveIDEZoomIndependenceSetting:)
                                                   keyEquivalent:@""];
         independentZoom.state = [self _shouldAdjustIDEFontSizesIndependently] ? NSOnState : NSOffState;


### PR DESCRIPTION
Follow-up to #10.

I reintroduced the independent font size adjustment for the main editor and console, this time with a user preference. This should satisfy all parties (me and everyone else :smiley:). By default, both the editor and console font size will be zoomed together.

![menu](https://cloud.githubusercontent.com/assets/1256911/13242336/9d7604ce-d9a8-11e5-84b9-89b9fd5fdd36.png)

